### PR TITLE
Collections not displaying for logged in users. 

### DIFF
--- a/upload/includes/classes/collections.class.php
+++ b/upload/includes/classes/collections.class.php
@@ -161,7 +161,7 @@ class Collection
         if (config('hide_empty_collection') == 'yes' && $param_hide_empty_collection !== 'no') {
             $hide_empty_collection = 'COUNT( DISTINCT collection_items.ci_id > 0 )';
             if( !empty(User::getInstance()->getCurrentUserID()) ){
-                $hide_empty_collection = '(' . $hide_empty_collection . ' OR ' . $this->getTableName() . 'userid = ' . User::getInstance()->getCurrentUserID() . ')';
+                $hide_empty_collection = '(' . $hide_empty_collection . ' OR ' . $this->getTableName() . '.userid = ' . User::getInstance()->getCurrentUserID() . ')';
             }
             $param_having[] = $hide_empty_collection;
         }


### PR DESCRIPTION
Collections not displaying for logged in users. Guests are view collection normally.
SQL ERROR : Unknown column 'collectionsuserid' in 'having clause' Collection does not exist.
Typo - missed dot, parameter didn't combine as  'collections.userid'
