### PR TITLE
Add Google Analytics 4 plugin with video engagement tracking

### DIFF
--- a/upload/plugins/Google_Analytics_4/README.md
+++ b/upload/plugins/Google_Analytics_4/README.md
@@ -1,0 +1,52 @@
+# Google Analytics 4 for ClipBucket V5
+
+**Version:** 1.1.2  
+**Author:** ZakHao
+
+Optional Google Analytics 4 integration for ClipBucket V5. The plugin adds GA4 page-view tracking and video engagement tracking for ClipBucket V5's HTML5/Video.js player without modifying ClipBucket core templates.
+
+## Features
+
+- Configure the GA4 Measurement ID from the ClipBucket Admin Area.
+- Enable or disable tracking without editing site templates.
+- Automatic GA4 page-view tracking.
+- Video start and resume tracking.
+- Video pause tracking.
+- Video progress tracking at 10%, 25%, 50%, 75%, and 90%.
+- Video seek tracking.
+- Video completion tracking.
+- Video metadata parameters: `video_id`, `video_title`, `video_duration`, and `video_current_time`.
+- Accumulated watch-time reporting for pause/progress/completion events.
+
+## Video events
+
+| Event | Description |
+| --- | --- |
+| `video_start` | First playback of a video |
+| `video_resume` | Playback resumed after a pause |
+| `video_pause` | Video paused |
+| `video_progress` | First reach of 10%, 25%, 50%, 75%, or 90% |
+| `video_seek` | User seeks to another position |
+| `video_complete` | Video playback reaches the end |
+
+## Installation
+
+1. Copy the `Google_Analytics_4` directory to `upload/plugins/`.
+2. Install the plugin from the ClipBucket Admin Area.
+3. Open **Google Analytics 4** from the plugin configuration menu.
+4. Enter your GA4 Measurement ID, for example `G-XXXXXXXXXX`.
+5. Enable the plugin and save the settings.
+
+The plugin stores its configuration in `plugin_ga4`. It does not require changes to `global_header.html`.
+
+## Compatibility
+
+Tested with ClipBucket V5.5.3 and its HTML5/Video.js player.
+
+## Notes
+
+The GA4 loader reads the configured Measurement ID server-side and generates the Google Analytics loader URL at runtime. This avoids relying on Smarty variable interpolation inside a header file registered through ClipBucket's plugin header mechanism.
+
+## Author
+
+ZakHao

--- a/upload/plugins/Google_Analytics_4/admin/ga4_config.html
+++ b/upload/plugins/Google_Analytics_4/admin/ga4_config.html
@@ -1,0 +1,22 @@
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Google Analytics 4</h3>
+            </div>
+            <div class="panel-body">
+                <form method="post" action="">
+                    <div class="form-group">
+                        <label for="measurement_id">Measurement ID</label>
+                        <input type="text" class="form-control" id="measurement_id" name="measurement_id" value="{$ga4_measurement_id|escape:'html'}" placeholder="G-XXXXXXXXXX" maxlength="32">
+                        <p class="help-block">Example: G-XXXXXXXXXX</p>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" name="enabled" value="yes" {if $ga4_enabled == 'yes'}checked{/if}> Enable Google Analytics 4</label>
+                    </div>
+                    <button type="submit" name="update" value="1" class="btn btn-primary">Save Settings</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/upload/plugins/Google_Analytics_4/admin/ga4_config.php
+++ b/upload/plugins/Google_Analytics_4/admin/ga4_config.php
@@ -1,0 +1,29 @@
+<?php
+const THIS_PAGE = 'ga4_config';
+require_once dirname(__DIR__, 3) . '/includes/admin_config.php';
+
+$breadcrumb[0] = ['title' => lang('configurations'), 'url' => ''];
+$breadcrumb[1] = [
+    'title' => 'Google Analytics 4',
+    'url' => DirPath::getUrl('plugins') . 'Google_Analytics_4/admin/ga4_config.php'
+];
+
+pages::getInstance()->page_redir();
+
+if (isset($_POST['update'])) {
+    try {
+        ga4::getInstance();
+        ga4::updateConfig($_POST['enabled'] ?? 'no', $_POST['measurement_id'] ?? '');
+        e('Google Analytics 4 settings have been updated.', 'm');
+    } catch (Exception $e) {
+        e($e->getMessage(), 'e');
+    }
+}
+
+$config = ga4::getConfig();
+assign('ga4_enabled', $config['enabled'] ?? 'no');
+assign('ga4_measurement_id', $config['measurement_id'] ?? '');
+
+subtitle('Google Analytics 4');
+template_files('ga4_config.html', DirPath::get('plugins') . basename(dirname(__DIR__)) . '/admin/');
+display_it();

--- a/upload/plugins/Google_Analytics_4/ga4.php
+++ b/upload/plugins/Google_Analytics_4/ga4.php
@@ -1,0 +1,69 @@
+<?php
+/*
+    Plugin Name: Google Analytics 4
+    Description: Adds Google Analytics 4 and HTML5/Video.js video engagement tracking to ClipBucket V5.
+    Author: ZakHao
+    Website: https://www.loonervideo.com/
+    Version: 1.1.2
+    ClipBucket Version: 5.5.3
+*/
+
+class ga4
+{
+    private static self $plugin;
+    public string $template_dir = '';
+    public static string $table_name = 'plugin_' . self::class;
+
+    public function __construct()
+    {
+        $this->template_dir = DirPath::get('plugins') . basename(__DIR__) . DIRECTORY_SEPARATOR . 'template' . DIRECTORY_SEPARATOR;
+
+        if (User::getInstance()->hasAdminAccess()) {
+            $this->addAdminMenu();
+        }
+
+        $config = self::getConfig();
+        assign('ga4_measurement_id', htmlspecialchars($config['measurement_id'] ?? '', ENT_QUOTES, 'UTF-8'));
+        assign('ga4_enabled', $config['enabled'] ?? 'no');
+        add_header($this->template_dir . 'ga4_header.html');
+    }
+
+    public static function getInstance(): self
+    {
+        if (empty(self::$plugin)) {
+            self::$plugin = new self();
+        }
+        return self::$plugin;
+    }
+
+    private function addAdminMenu(): void
+    {
+        add_admin_menu(
+            lang('configurations'),
+            'Google Analytics 4',
+            DirPath::getUrl('plugins') . basename(__DIR__) . '/admin/ga4_config.php'
+        );
+    }
+
+    public static function getConfig(): array
+    {
+        $results = Clipbucket_db::getInstance()->select(tbl(self::$table_name), '*');
+        return $results[0] ?? ['enabled' => 'no', 'measurement_id' => ''];
+    }
+
+    public static function updateConfig($enabled, $measurement_id): void
+    {
+        $enabled = $enabled === 'yes' ? 'yes' : 'no';
+        $measurement_id = trim((string)$measurement_id);
+
+        if ($enabled === 'yes' && !preg_match('/^G-[A-Z0-9]+$/i', $measurement_id)) {
+            throw new Exception('Please enter a valid GA4 Measurement ID, for example G-XXXXXXXXXX.');
+        }
+
+        $sql = 'UPDATE ' . tbl(self::$table_name)
+            . " SET enabled='" . mysql_clean($enabled) . "', measurement_id='" . mysql_clean($measurement_id) . "'";
+        Clipbucket_db::getInstance()->execute($sql);
+    }
+}
+
+ga4::getInstance();

--- a/upload/plugins/Google_Analytics_4/ga4_loader.php
+++ b/upload/plugins/Google_Analytics_4/ga4_loader.php
@@ -1,0 +1,181 @@
+<?php
+/*
+ * ClipBucket GA4 runtime loader
+ * Author: ZakHao
+ * Version: 1.1.2
+ *
+ * This endpoint intentionally does not use Smarty. ClipBucket's add_header()
+ * registers this header file directly, so Smarty variables in that file are
+ * not rendered. The Measurement ID is read from the plugin table here and
+ * emitted as JavaScript.
+ */
+
+header('Content-Type: application/javascript; charset=UTF-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+
+require_once dirname(__DIR__, 2) . '/includes/common.php';
+
+$table = tbl('plugin_ga4');
+$rows = Clipbucket_db::getInstance()->select($table, '*');
+$config = $rows[0] ?? ['enabled' => 'no', 'measurement_id' => ''];
+
+if (($config['enabled'] ?? 'no') !== 'yes') {
+    echo "/* GA4 disabled */\n";
+    exit;
+}
+
+$measurement_id = trim((string)($config['measurement_id'] ?? ''));
+if (!preg_match('/^G-[A-Z0-9]+$/i', $measurement_id)) {
+    echo "/* GA4 measurement ID is not configured */\n";
+    exit;
+}
+
+$measurement_id_js = json_encode($measurement_id, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+?>
+(function () {
+    'use strict';
+
+    var measurementId = <?php echo $measurement_id_js; ?>;
+
+    if (!measurementId || window.__cbGa4Loaded) return;
+    window.__cbGa4Loaded = true;
+    window.ga4MeasurementId = measurementId;
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
+    window.gtag('js', new Date());
+    window.gtag('config', measurementId);
+
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(measurementId);
+    document.head.appendChild(script);
+
+    function getVideoInfo(video) {
+        var id = '';
+        var match = (video.id || '').match(/^cb_video_js_(\d+)_html5_api$/);
+        if (match) id = match[1];
+        else if (video.id) id = video.id;
+
+        var title = document.title || '';
+        var titleNode = document.querySelector('.video-title, .video_title, h1.video-title, h1.video_title');
+        if (titleNode && titleNode.textContent.trim()) title = titleNode.textContent.trim();
+
+        return {
+            video_id: id,
+            video_title: title,
+            video_duration: Number.isFinite(video.duration) ? Math.round(video.duration) : 0
+        };
+    }
+
+    function sendVideoEvent(name, video, extra) {
+        if (typeof window.gtag !== 'function') return;
+        var info = getVideoInfo(video);
+        var params = {
+            video_id: info.video_id,
+            video_title: info.video_title,
+            video_duration: info.video_duration,
+            video_current_time: Math.round(video.currentTime || 0)
+        };
+        if (extra) {
+            Object.keys(extra).forEach(function (key) { params[key] = extra[key]; });
+        }
+        window.gtag('event', name, params);
+    }
+
+    function initVideoTracking(video) {
+        if (!video || video.dataset.ga4TrackingInitialized === '1') return;
+        video.dataset.ga4TrackingInitialized = '1';
+
+        var sentProgress = {};
+        var started = false;
+        var wasPlaying = false;
+        var seeking = false;
+        var seekFrom = 0;
+        var watchTime = 0;
+        var lastTick = 0;
+        var progressMarks = [10, 25, 50, 75, 90];
+
+        video.addEventListener('play', function () {
+            if (!started) {
+                started = true;
+                sendVideoEvent('video_start', video);
+            } else if (!wasPlaying) {
+                sendVideoEvent('video_resume', video);
+            }
+            wasPlaying = true;
+            lastTick = Date.now();
+        });
+
+        video.addEventListener('pause', function () {
+            if (wasPlaying) {
+                sendVideoEvent('video_pause', video, { video_watch_time: Math.round(watchTime) });
+            }
+            wasPlaying = false;
+        });
+
+        video.addEventListener('timeupdate', function () {
+            var now = Date.now();
+            if (wasPlaying && lastTick) {
+                var delta = (now - lastTick) / 1000;
+                if (delta > 0 && delta < 5) watchTime += delta;
+            }
+            lastTick = now;
+
+            var duration = video.duration;
+            if (!Number.isFinite(duration) || duration <= 0) return;
+            var percent = (video.currentTime / duration) * 100;
+            progressMarks.forEach(function (mark) {
+                if (percent >= mark && !sentProgress[mark]) {
+                    sentProgress[mark] = true;
+                    sendVideoEvent('video_progress', video, {
+                        video_percent: mark,
+                        video_watch_time: Math.round(watchTime)
+                    });
+                }
+            });
+        });
+
+        video.addEventListener('seeking', function () {
+            if (!seeking) {
+                seeking = true;
+                seekFrom = video.currentTime || 0;
+            }
+        });
+
+        video.addEventListener('seeked', function () {
+            if (seeking) {
+                var seekTo = video.currentTime || 0;
+                sendVideoEvent('video_seek', video, {
+                    video_seek_from: Math.round(seekFrom),
+                    video_seek_to: Math.round(seekTo)
+                });
+                seeking = false;
+            }
+        });
+
+        video.addEventListener('ended', function () {
+            if (wasPlaying && lastTick) {
+                var delta = (Date.now() - lastTick) / 1000;
+                if (delta > 0 && delta < 5) watchTime += delta;
+            }
+            wasPlaying = false;
+            sendVideoEvent('video_complete', video, {
+                video_percent: 100,
+                video_watch_time: Math.round(watchTime)
+            });
+        });
+    }
+
+    function scanVideos() {
+        document.querySelectorAll('video.vjs-tech, video[id*="_html5_api"]').forEach(initVideoTracking);
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', scanVideos);
+    else scanVideos();
+
+    if (window.MutationObserver) {
+        var observer = new MutationObserver(function () { scanVideos(); });
+        observer.observe(document.documentElement, { childList: true, subtree: true });
+    }
+})();

--- a/upload/plugins/Google_Analytics_4/install_ga4.php
+++ b/upload/plugins/Google_Analytics_4/install_ga4.php
@@ -1,0 +1,6 @@
+<?php
+function install_ga4(): void
+{
+    execute_sql_file(__DIR__ . DIRECTORY_SEPARATOR . 'sql' . DIRECTORY_SEPARATOR . 'install.sql');
+}
+install_ga4();

--- a/upload/plugins/Google_Analytics_4/sql/install.sql
+++ b/upload/plugins/Google_Analytics_4/sql/install.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `{tbl_prefix}plugin_ga4` (
+    `enabled` enum('yes','no') NOT NULL DEFAULT 'no',
+    `measurement_id` varchar(32) NOT NULL DEFAULT ''
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO `{tbl_prefix}plugin_ga4` (`enabled`, `measurement_id`)
+SELECT 'no', ''
+WHERE NOT EXISTS (SELECT 1 FROM `{tbl_prefix}plugin_ga4` LIMIT 1);

--- a/upload/plugins/Google_Analytics_4/sql/uninstall.sql
+++ b/upload/plugins/Google_Analytics_4/sql/uninstall.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `{tbl_prefix}plugin_ga4`;

--- a/upload/plugins/Google_Analytics_4/template/ga4_header.html
+++ b/upload/plugins/Google_Analytics_4/template/ga4_header.html
@@ -1,0 +1,3 @@
+{if $ga4_enabled == 'yes'}
+<script src="/plugins/Google_Analytics_4/ga4_loader.php"></script>
+{/if}

--- a/upload/plugins/Google_Analytics_4/uninstall_ga4.php
+++ b/upload/plugins/Google_Analytics_4/uninstall_ga4.php
@@ -1,0 +1,6 @@
+<?php
+function uninstall_ga4(): void
+{
+    execute_sql_file(__DIR__ . DIRECTORY_SEPARATOR . 'sql' . DIRECTORY_SEPARATOR . 'uninstall.sql');
+}
+uninstall_ga4();


### PR DESCRIPTION
This PR adds a Google Analytics 4 integration plugin for ClipBucket V5.

The plugin allows administrators to configure a GA4 Measurement ID from the ClipBucket Admin Area without modifying ClipBucket core files or templates.

### Features

* Google Analytics 4 page view tracking
* Admin configuration page for the GA4 Measurement ID
* Enable / disable GA4 tracking
* Video start tracking
* Video pause and resume tracking
* Video seek tracking
* Video progress tracking at 10%, 25%, 50%, 75% and 90%
* Video completion tracking
* Video ID and video title tracking
* Video duration and current playback position tracking
* Accumulated video watch time tracking

### Video Events

The plugin reports the following custom video events to GA4:

* `video_start`
* `video_progress`
* `video_pause`
* `video_resume`
* `video_seek`
* `video_complete`

Video events include useful parameters such as `video_id`, `video_title`, `video_duration`, `video_current_time`, `video_percent`, and `video_watch_time`.

### Implementation

The plugin uses the existing ClipBucket V5 plugin system and does not require modifications to the ClipBucket core video player.

The GA4 JavaScript loader retrieves the configured Measurement ID server-side and dynamically loads the Google Analytics script.

Video tracking works with the existing Video.js HTML5 player used by ClipBucket V5.

### Testing

The plugin has been tested on a live ClipBucket V5 installation.

The following have been verified successfully in Google Analytics 4:

* Page views
* Active users
* Video start events
* Video progress events
* Video pause/resume events
* Video seek events
* Video completion events

No ClipBucket core files need to be modified to use this plugin.

Author: ZakHao